### PR TITLE
Fixed Actor.dispose from throwing WebGL deleteTexture Error

### DIFF
--- a/source/Actor.js
+++ b/source/Actor.js
@@ -73,7 +73,7 @@ var Actor = (function ()
 			for(var i = 0; i < atlases.length; i++)
 			{
 				var atlas = atlases[i];
-				graphics.deleteTexture(graphics);
+				graphics.deleteTexture(atlas);
 			}
 		}
 		var images = this._Images;


### PR DESCRIPTION
Fixed Actor.dispose to properly pass the atlas to the deleteTexture function.