### PR TITLE
Added support for getting a webgl2 context for the graphics object.

### DIFF
--- a/source/Graphics.js
+++ b/source/Graphics.js
@@ -7,7 +7,7 @@ var Graphics = (function()
 			preserveDrawingBuffer: true
 		};
 
-		var _GL = canvas.getContext("webgl", contextOptions) || canvas.getContext("experimental-webgl", contextOptions);
+		var _GL = canvas.getContext("webgl", contextOptions) || canvas.getContext("experimental-webgl", contextOptions) || canvas.getContext("webgl2", contextOptions);
 
 		var _AnisotropyExtension = _GL.getExtension("EXT_texture_filter_anisotropic");
 		var _MaxAnisotropy;


### PR DESCRIPTION
I originally was getting errors in Chrome because _GL was null. This resolved my issues.